### PR TITLE
First step in fixing Windows build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -47,7 +47,7 @@
 
   <target name="build" depends="prep">
     <echo file="src/main/resources/VERSION" append="false">1.0.${DSTAMP} 32-bit</echo>
-    <exec executable="mvn.bat" failonerror="true" osfamily="windows">
+    <exec executable="mvn.cmd" failonerror="true" osfamily="windows">
       <arg value="-U" />
       <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86_64,osx-x86,osx-x86_64"' />
       <arg value="clean" />

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <maven.build.timestamp.format>yyyMMdd-HHmmss</maven.build.timestamp.format>
   </properties>
 
   <repositories>
@@ -26,7 +28,7 @@
   </repositories>
 
   <build>
-   <finalName>${project.artifactId}-${project.version}-${maven.build.timestamp}</finalName>
+   <finalName>${project.artifactId}-${project.version}-${timestamp}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- mvn.bat renamed to mvn.cmd in Maven 3.3.3+
- Fix issue with time stamp and path name

@scytacki Banking some minor changes before getting involved with the new Vernier libraries.