### PR TITLE
Pass `APP_VERSION` environment variable to WiX installer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -119,7 +119,9 @@
 
   <target name="win-bundle" depends="fx-package">
     <copy file="dist/${APP_TIMESTAMPED_NAME}.msi" tofile="dist/${APP_NAME}.msi" />
-    <exec executable="script/win-bundle.bat" />
+    <exec executable="script/win-bundle.bat">
+      <env key="APP_VERSION" value="${APP_VERSION}"/>
+    </exec>
     <move file="dist/${APP_NAME}-bundle.exe" tofile="dist/${APP_TIMESTAMPED_NAME}-unsigned.exe" />
     <exec executable="insignia.exe" dir="dist" failonerror="false">
       <arg line='-ib ${APP_TIMESTAMPED_NAME}-unsigned.exe -o engine.exe' />

--- a/resources/win-bundles.wxs
+++ b/resources/win-bundles.wxs
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <!-- Make sure the version here matches the new version in the MSI definition (SensorConnector.wxs). -->
+  <?ifndef env.APP_VERSION ?>
+    <?error "APP_VERSION environment variable must be defined!" ?>
+  <?endif ?>
   <Bundle
-      Version="1.1.1"
+      Version="$(env.APP_VERSION)"
       AboutUrl="http://sensorconnector.concord.org/"
       DisableModify="yes"
       Manufacturer="Concord Consortium, Inc."

--- a/script/win-bundle.bat
+++ b/script/win-bundle.bat
@@ -1,2 +1,3 @@
 candle -ext WixUtilExtension -ext WixBalExtension -out tmp\ resources\win-bundles.wxs
+if %errorlevel% neq 0 exit /b %errorlevel%
 light  -ext WixUtilExtension -ext WixBalExtension tmp\*.wixobj -o dist\SensorConnector-bundle.exe


### PR DESCRIPTION
Pass `APP_VERSION` environment variable to WiX installer
- `win-bundle.bat` stops on error