### PR TITLE
159744652 build 64 bit sensorconnector

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -149,7 +149,7 @@
 
   <target name="win-bundle-x64" depends="build-win-x64, fx-package, win-bundle" />
 
-  <target name="win-bundle-x32" depends="build, fx-package, win-bundle" />
+  <target name="win-bundle-x86" depends="build, fx-package, win-bundle" />
 
   <target name="mac-stage" depends="build">
     <condition property="jre" value="/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK">

--- a/build.xml
+++ b/build.xml
@@ -93,7 +93,7 @@
     </exec>
   </target>
 
-  <target name="fx-package" depends="build">
+  <target name="fx-package">
     <fail unless="env.JAVA_HOME" message="You must set JAVA_HOME (eg: 'export JAVA_HOME=`/usr/libexec/java_home`')" />
     <copy todir="target/dependency">
       <fileset dir="target">
@@ -129,43 +129,7 @@
     <move file="dist/bundles/${APP_VERSIONED_NAME}.msi" tofile="dist/${APP_TIMESTAMPED_NAME}.msi" />
   </target>
 
-   <target name="fx-package-x64" depends="build-win-x64">
-    <fail unless="env.JAVA_HOME" message="You must set JAVA_HOME (eg: 'export JAVA_HOME=`/usr/libexec/java_home`')" />
-    <copy todir="target/dependency">
-      <fileset dir="target">
-        <include name="sensor-connector-*.jar" />
-      </fileset>
-    </copy>
-    <fx:deploy verbose="true" nativeBundles="msi" width="100" height="100" outdir="dist/" outfile="SensorConnector">
-      <info title="Sensor Connector" vendor="Concord Consortium" description="Sensor Connector Application" />
-      <fx:application mainClass="org.concord.sensor.server.SensorConnector" toolkit="swing"/>
-      <fx:resources>
-        <fx:fileset dir="target/dependency">
-          <include name="**/*.jar" />
-        </fx:fileset>
-        <fx:fileset dir="${env.JAVA_HOME}/jre/bin">
-          <include name="msvcr100.dll" />
-        </fx:fileset>
-        <fx:fileset dir="resources">
-          <include name="ca.cert.pem" />
-          <include name="win-install-cert.bat" />
-          <include name="win-uninstall-cert.bat" />
-          <include name="cert8.db" />
-          <include name="key3.db" />
-          <include name="secmod.db" />
-        </fx:fileset>
-        <fx:fileset dir="resources/certutil">
-          <include name="**/*" />
-        </fx:fileset>
-      </fx:resources>
-    </fx:deploy>
-    <exec executable="signtool.exe" dir="dist/bundles" failonerror="false">
-      <arg line="sign /n '${certname}' /tr http://tsa.starfieldtech.com /td SHA256 /v SensorConnector-1.0.msi" />
-    </exec>
-    <move file="dist/bundles/SensorConnector-1.0.msi" tofile="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}.msi" />
-  </target>
-
-  <target name="win-bundle" depends="fx-package">
+  <target name="win-bundle">
     <copy file="dist/${APP_TIMESTAMPED_NAME}.msi" tofile="dist/${APP_NAME}.msi" />
     <exec executable="script/win-bundle.bat">
       <env key="APP_VERSION" value="${APP_VERSION}"/>
@@ -183,21 +147,9 @@
     <echo message="Built: ${APP_TIMESTAMPED_NAME}" />
   </target>
 
-   <target name="win-bundle-x64" depends="fx-package-x64">
-    <copy file="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}.msi" tofile="dist/SensorConnector.msi" />
-    <exec executable="script/win-bundle.bat" />
-    <move file="dist/SensorConnector-bundle.exe" tofile="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe" />
-    <exec executable="insignia.exe" dir="dist" failonerror="false">
-      <arg line='-ib SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe -o engine.exe' />
-    </exec>
-    <exec executable="signtool.exe" dir="dist" failonerror="false">
-      <arg line="sign /n '${certname}' /tr http://tsa.starfieldtech.com /td SHA256 /v engine.exe" />
-    </exec>
-    <exec executable="insignia.exe" dir="dist" failonerror="false">
-      <arg line='-ab engine.exe SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe -o SensorConnector-x64-${DSTAMP}-${TSTAMP}.exe' />
-    </exec>
-    <echo message="Built: ${APP_TIMESTAMPED_NAME}" />
-  </target>
+  <target name="win-bundle-x64" depends="build-win-x64, fx-package, win-bundle" />
+
+  <target name="win-bundle-x32" depends="build, fx-package, win-bundle" />
 
   <target name="mac-stage" depends="build">
     <condition property="jre" value="/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK">

--- a/build.xml
+++ b/build.xml
@@ -54,7 +54,6 @@
   </target>
 
   <target name="build" depends="prep">
-    <echo file="src/main/resources/VERSION" append="false">${APP_VERSION}.${DSTAMP} 32-bit</echo>
     <exec executable="mvn.cmd" failonerror="true" osfamily="windows">
       <arg value="-U" />
       <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86_64,osx-x86,osx-x86_64"' />
@@ -72,7 +71,6 @@
   </target>
 
   <target name="build-win-x64" depends="prep">
-    <echo file="src/main/resources/VERSION" append="false">${APP_VERSION}.${DSTAMP} 64-bit</echo>
     <exec executable="mvn.cmd" failonerror="true" osfamily="windows">
       <arg value="-U" />
       <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86,osx-x86,osx-x86_64"' />
@@ -83,7 +81,6 @@
   </target>
 
   <target name="build-mac-x64" depends="prep">
-    <echo file="src/main/resources/VERSION" append="false">${APP_VERSION}.${DSTAMP} 64-bit</echo>
     <exec executable="mvn" failonerror="true" osfamily="mac">
       <arg value="-U" />
       <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86,windows-x86_64"' />

--- a/build.xml
+++ b/build.xml
@@ -34,8 +34,9 @@
     <isset property="env.JRE_HOME" />
   </condition>
 
+  <echo message="Using JDK located at: ${env.JAVA_HOME}" />
   <taskdef name="bundleapp" classname="com.oracle.appbundler.AppBundlerTask" classpath="lib/appbundler-1.0ea.jar" />
-  <taskdef resource="com/sun/javafx/tools/ant/antlib.xml" uri="javafx:com.sun.javafx.tools.ant" classpath=".:lib/ant-javafx.jar" />
+  <taskdef resource="com/sun/javafx/tools/ant/antlib.xml" uri="javafx:com.sun.javafx.tools.ant" classpath=".;${env.JAVA_HOME}/lib/ant-javafx.jar"/>
 
   <target name="clean">
     <delete removeNotFollowedSymlinks="true" followSymlinks="false" includeEmptyDirs="true" failonerror="false">
@@ -64,6 +65,17 @@
     <exec executable="mvn" failonerror="true" osfamily="mac">
       <arg value="-U" />
       <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86,windows-x86_64"' />
+      <arg value="clean" />
+      <arg value="package" />
+      <arg value="dependency:copy-dependencies" />
+    </exec>
+  </target>
+
+  <target name="build-win-x64" depends="prep">
+    <echo file="src/main/resources/VERSION" append="false">${APP_VERSION}.${DSTAMP} 64-bit</echo>
+    <exec executable="mvn.cmd" failonerror="true" osfamily="windows">
+      <arg value="-U" />
+      <arg value='-DexcludeClassifiers="linux-x86,linux-x86_64,linux-arm,windows-x86,osx-x86,osx-x86_64"' />
       <arg value="clean" />
       <arg value="package" />
       <arg value="dependency:copy-dependencies" />
@@ -117,6 +129,42 @@
     <move file="dist/bundles/${APP_VERSIONED_NAME}.msi" tofile="dist/${APP_TIMESTAMPED_NAME}.msi" />
   </target>
 
+   <target name="fx-package-x64" depends="build-win-x64">
+    <fail unless="env.JAVA_HOME" message="You must set JAVA_HOME (eg: 'export JAVA_HOME=`/usr/libexec/java_home`')" />
+    <copy todir="target/dependency">
+      <fileset dir="target">
+        <include name="sensor-connector-*.jar" />
+      </fileset>
+    </copy>
+    <fx:deploy verbose="true" nativeBundles="msi" width="100" height="100" outdir="dist/" outfile="SensorConnector">
+      <info title="Sensor Connector" vendor="Concord Consortium" description="Sensor Connector Application" />
+      <fx:application mainClass="org.concord.sensor.server.SensorConnector" toolkit="swing"/>
+      <fx:resources>
+        <fx:fileset dir="target/dependency">
+          <include name="**/*.jar" />
+        </fx:fileset>
+        <fx:fileset dir="${env.JAVA_HOME}/jre/bin">
+          <include name="msvcr100.dll" />
+        </fx:fileset>
+        <fx:fileset dir="resources">
+          <include name="ca.cert.pem" />
+          <include name="win-install-cert.bat" />
+          <include name="win-uninstall-cert.bat" />
+          <include name="cert8.db" />
+          <include name="key3.db" />
+          <include name="secmod.db" />
+        </fx:fileset>
+        <fx:fileset dir="resources/certutil">
+          <include name="**/*" />
+        </fx:fileset>
+      </fx:resources>
+    </fx:deploy>
+    <exec executable="signtool.exe" dir="dist/bundles" failonerror="false">
+      <arg line="sign /n '${certname}' /tr http://tsa.starfieldtech.com /td SHA256 /v SensorConnector-1.0.msi" />
+    </exec>
+    <move file="dist/bundles/SensorConnector-1.0.msi" tofile="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}.msi" />
+  </target>
+
   <target name="win-bundle" depends="fx-package">
     <copy file="dist/${APP_TIMESTAMPED_NAME}.msi" tofile="dist/${APP_NAME}.msi" />
     <exec executable="script/win-bundle.bat">
@@ -131,6 +179,22 @@
     </exec>
     <exec executable="insignia.exe" dir="dist" failonerror="false">
       <arg line='-ab engine.exe ${APP_TIMESTAMPED_NAME}-unsigned.exe -o ${APP_TIMESTAMPED_NAME}.exe' />
+    </exec>
+    <echo message="Built: ${APP_TIMESTAMPED_NAME}" />
+  </target>
+
+   <target name="win-bundle-x64" depends="fx-package-x64">
+    <copy file="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}.msi" tofile="dist/SensorConnector.msi" />
+    <exec executable="script/win-bundle.bat" />
+    <move file="dist/SensorConnector-bundle.exe" tofile="dist/SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe" />
+    <exec executable="insignia.exe" dir="dist" failonerror="false">
+      <arg line='-ib SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe -o engine.exe' />
+    </exec>
+    <exec executable="signtool.exe" dir="dist" failonerror="false">
+      <arg line="sign /n '${certname}' /tr http://tsa.starfieldtech.com /td SHA256 /v engine.exe" />
+    </exec>
+    <exec executable="insignia.exe" dir="dist" failonerror="false">
+      <arg line='-ab engine.exe SensorConnector-x64-${DSTAMP}-${TSTAMP}-unsigned.exe -o SensorConnector-x64-${DSTAMP}-${TSTAMP}.exe' />
     </exec>
     <echo message="Built: ${APP_TIMESTAMPED_NAME}" />
   </target>

--- a/package/windows/SensorConnector.wxs
+++ b/package/windows/SensorConnector.wxs
@@ -1,4 +1,15 @@
-<?xml version="1.0" encoding="windows-1252"?>
+<?xml version="1.0" encoding="windows-1252"?> 
+
+<?if $(env.SC_ARCH_BITS) = "64" ?>
+  <?warning build is 64 bits, specify version in win-build.sh if this is incorrect ?>
+  <?define Win64 = "yes" ?>
+  <?define Platform = "x64" ?>
+<?else ?>
+  <?warning build is 32 bits, specify version in win-build.sh if this is incorrect ?>
+  <?define Win64 = "no" ?>
+  <?define Platform = "x86" ?>
+<?endif ?>
+
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <!-- When packaging a new installer, regenerate the product id, and
@@ -11,6 +22,7 @@
         <Package Description="Sensor Connector Application" Comments="None"
                  InstallerVersion="310" Compressed="yes"
                  InstallPrivileges="elevated"
+                 Platform="$(var.Platform)"
                  InstallScope="perMachine"/>
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" />
         <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" Secure="yes" />
@@ -35,7 +47,7 @@
                             Id="APPLICATIONFOLDER_REGSEARCH" Name="Path" />
         </Property>
         <DirectoryRef Id="APPLICATIONFOLDER">
-            <Component Id="CleanupMainApplicationFolder" Guid="e944efdd-3ecc-45e4-9ba2-7a1814aa0d1e">
+            <Component Id="CleanupMainApplicationFolder" Guid="e944efdd-3ecc-45e4-9ba2-7a1814aa0d1e" Win64="$(var.Win64)">
                 <RegistryValue Root="HKLM"
                                    Key="SOFTWARE\Concord Consortium\SensorConnector"
                                    Name="Path" Type="string" Value="[APPLICATIONFOLDER]"

--- a/script/win-build.sh
+++ b/script/win-build.sh
@@ -9,7 +9,7 @@ export SC_APP_VERSION=`cat version.txt`
 if [[ ("$1" == "-32") || ($# -eq 0) ]]; then
 	export SC_ARCH_BITS=32
 	rm -rf dist
-	ant win-bundle-x32 && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
+	ant win-bundle-x86 && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
 	rm *unsigned*
 fi
 

--- a/script/win-build.sh
+++ b/script/win-build.sh
@@ -1,8 +1,22 @@
 #!/bin/sh
 
-export SC_APP_VERSION=`cat version.txt`
-export SC_ARCH_BITS=32
+# Usage: With no arguments builds 32-bit and 64-bit packages
+#        Use "-32" or "-64" argument to build 32-bit/64-bit package only
 
-rm -rf dist
-ant win-bundle && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
-rm *unsigned*
+export SC_APP_VERSION=`cat version.txt`
+
+# build 32-bit package
+if [[ ("$1" == "-32") || ($# -eq 0) ]]; then
+	export SC_ARCH_BITS=32
+	rm -rf dist
+	ant win-bundle && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
+	rm *unsigned*
+fi
+
+# build 64-bit package
+if [[ ("$1" == "-64") ]]; then
+	export SC_ARCH_BITS=64
+	rm -rf dist
+	ant win-bundle-x64 && mv dist/SensorConnector-x64-*.msi . && mv dist/SensorConnector-x64-*.exe .
+	rm *unsigned*
+fi

--- a/script/win-build.sh
+++ b/script/win-build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Usage: With no arguments builds 32-bit and 64-bit packages
+# Usage: With no arguments builds 32-bit package
 #        Use "-32" or "-64" argument to build 32-bit/64-bit package only
 
 export SC_APP_VERSION=`cat version.txt`

--- a/script/win-build.sh
+++ b/script/win-build.sh
@@ -9,7 +9,7 @@ export SC_APP_VERSION=`cat version.txt`
 if [[ ("$1" == "-32") || ($# -eq 0) ]]; then
 	export SC_ARCH_BITS=32
 	rm -rf dist
-	ant win-bundle && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
+	ant win-bundle-x32 && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
 	rm *unsigned*
 fi
 
@@ -17,6 +17,6 @@ fi
 if [[ ("$1" == "-64") ]]; then
 	export SC_ARCH_BITS=64
 	rm -rf dist
-	ant win-bundle-x64 && mv dist/SensorConnector-x64-*.msi . && mv dist/SensorConnector-x64-*.exe .
+	ant win-bundle-x64 && mv dist/SensorConnector-*.msi . && mv dist/SensorConnector-*.exe .
 	rm *unsigned*
 fi


### PR DESCRIPTION
I stripped back some of the redundancy by adjusting the task dependencies and merged from master to use your new build.xml properties.  I previously had some extra naming steps on the 64 bit build, but I ripped them out for the sake of simplicity.    Does this still work with Mac?  I'm mostly interested if anything that I changed with the classpath in build.xml has a detrimental affect on the Mac build.