### PR TITLE
Add Go Direct support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
     </dependency>
     <dependency>
       <groupId>org.concord.sensor</groupId>
+      <artifactId>d2pio-jna</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>		
+    <dependency>
+      <groupId>org.concord.sensor</groupId>
       <artifactId>labpro-usb-jna</artifactId>
       <version>1.0-SNAPSHOT</version>
     </dependency>

--- a/src/main/java/org/concord/sensor/DeviceFinder.java
+++ b/src/main/java/org/concord/sensor/DeviceFinder.java
@@ -80,6 +80,9 @@ public class DeviceFinder {
 			case 0x000B: // LabQuest 2
 				logger.fine("Found a Vernier LabQuest 2!");
 				return DeviceID.VERNIER_LAB_QUEST;
+			case 0x0010: // Go Direct
+				logger.fine("Found a Vernier Go Direct!");
+				return DeviceID.VERNIER_GO_DIRECT;				
 			}
 			throw new UnknownProductException("Vernier", productId);
 		case 0x0945: // Pasco
@@ -104,6 +107,8 @@ public class DeviceFinder {
 		case DeviceID.VERNIER_GO_LINK_JNA:
 		case DeviceID.VERNIER_GO_LINK_NATIVE:
 			return "Vernier GoLink!";
+		case DeviceID.VERNIER_GO_DIRECT:
+			return "Vernier Go Direct";			
 		case DeviceID.TI_CONNECT:
 			return "TI Connect"; // ???
 		case DeviceID.FOURIER:


### PR DESCRIPTION
Add Go Direct support when building project and when reading USB connected device id to determine sensor type.

Notes:
- we need to reach out to Vernier to determine if the product id for Go Direct sensors is always 0x10.
- additional changes are required in sensor-projects and are located here: https://github.com/concord-consortium/sensor-projects/tree/161195811-go-direct-sensor-connector-integration
